### PR TITLE
🔀 :: 학생 랭킹 페이지 제작

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -18,15 +18,20 @@ private func parent1(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Sc
 #if !NEEDLE_DYNAMIC
 
 private class StudentRankDependencye04f973d7ee2e4dbf097Provider: StudentRankDependency {
-
-
-    init() {
-
+    var fetchMyInfoUseCase: any FetchMyInfoUseCase {
+        return appComponent.fetchMyInfoUseCase
+    }
+    var fetchPointRankingListUseCase: any FetchPointRankingListUseCase {
+        return appComponent.fetchPointRankingListUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
     }
 }
 /// ^->AppComponent->StudentRankComponent
-private func factorya207e95657dad45fc3d1e3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
-    return StudentRankDependencye04f973d7ee2e4dbf097Provider()
+private func factorya207e95657dad45fc3d1f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return StudentRankDependencye04f973d7ee2e4dbf097Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class StudentMainDependencya9393ba8e6906aa5293fProvider: StudentMainDependency {
 
@@ -250,7 +255,8 @@ extension AppComponent: Registration {
 }
 extension StudentRankComponent: Registration {
     public func registerItems() {
-
+        keyPathToName[\StudentRankDependency.fetchMyInfoUseCase] = "fetchMyInfoUseCase-any FetchMyInfoUseCase"
+        keyPathToName[\StudentRankDependency.fetchPointRankingListUseCase] = "fetchPointRankingListUseCase-any FetchPointRankingListUseCase"
     }
 }
 extension StudentMainComponent: Registration {
@@ -339,7 +345,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
 
 @inline(never) private func register1() {
     registerProviderFactory("^->AppComponent", factoryEmptyDependencyProvider)
-    registerProviderFactory("^->AppComponent->StudentRankComponent", factorya207e95657dad45fc3d1e3b0c44298fc1c149afb)
+    registerProviderFactory("^->AppComponent->StudentRankComponent", factorya207e95657dad45fc3d1f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->StudentMainComponent", factory3f302b760f5a8a5bb663e3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->TeacherTabBarComponent", factoryc4bcf0b736b2cf3bd721f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->TeacherStoreComponent", factory128c5d3f23ae759e8449e3b0c44298fc1c149afb)

--- a/App/Sources/DesignSystem/Row/RankingListRow.swift
+++ b/App/Sources/DesignSystem/Row/RankingListRow.swift
@@ -20,6 +20,7 @@ public struct RankingListRow: View {
                 .frame(width: 50, height: 50)
                 .scaledToFit()
                 .clipShape(Circle())
+                .frame(width: 110, height: 110)
 
                 Text(name)
                     .skFont(.pm14)

--- a/App/Sources/DesignSystem/Row/RankingListRow.swift
+++ b/App/Sources/DesignSystem/Row/RankingListRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 public struct RankingListRow: View {
     let ranking: String
-    let profileImage: String
+    let profileURL: String?
     let name: String
     let point: Int
 
@@ -12,15 +12,21 @@ public struct RankingListRow: View {
                 Text(ranking)
                     .skFont(.pm20)
 
-                AsyncImage(url: URL(string: profileImage)) { image in
-                    image.resizable()
-                } placeholder: {
-                    ProgressView()
+                if let profileURL = profileURL {
+                    AsyncImage(url: URL(string: profileURL)) { image in
+                        image.resizable()
+                    } placeholder: {
+                        ProgressView()
+                    }
+                    .scaledToFit()
+                    .clipShape(Circle())
+                    .frame(width: 50, height: 50)
+                } else {
+                    SKBaseProfileImage(.BaseProfileImage)
+                        .scaledToFit()
+                        .clipShape(Circle())
+                        .frame(width: 50, height: 50)
                 }
-                .frame(width: 50, height: 50)
-                .scaledToFit()
-                .clipShape(Circle())
-                .frame(width: 110, height: 110)
 
                 Text(name)
                     .skFont(.pm14)

--- a/App/Sources/Presentation/Root/RootView.swift
+++ b/App/Sources/Presentation/Root/RootView.swift
@@ -29,7 +29,7 @@ struct RootView: View {
                     .environmentObject(sceneState)
 
             case .studentMain:
-                AnyView(teacherTabBarFactory.makeView())
+                AnyView(studentTabBarFactory.makeView())
                     .environmentObject(sceneState)
             }
         }

--- a/App/Sources/Presentation/StudentRank/Source/DI/StudentRankComponent.swift
+++ b/App/Sources/Presentation/StudentRank/Source/DI/StudentRankComponent.swift
@@ -1,10 +1,28 @@
-import NeedleFoundation
 import SwiftUI
 
-public protocol StudentRankDependency: Dependency {}
+import Service
+import NeedleFoundation
+
+public protocol StudentRankDependency: Dependency {
+    var fetchMyInfoUseCase: any FetchMyInfoUseCase { get }
+    var fetchPointRankingListUseCase: any FetchPointRankingListUseCase { get }
+}
 
 public final class StudentRankComponent: Component<StudentRankDependency>, StudentRankFactory {
     public func makeView() -> some View {
-        StudentRankView()
+        let model = StudentRankModel()
+        let intent = StudentRankIntent(
+            model: model,
+            fetchMyInfoUseCase: dependency.fetchMyInfoUseCase,
+            fetchPointRankingListUseCase: dependency.fetchPointRankingListUseCase
+        )
+
+        let container = MVIContainer(
+            intent: intent as StudentRankIntentProtocol,
+            model: model as StudentRankModelStateProtocol,
+            modelChangePublisher: model.objectWillChange
+        )
+
+        return StudentRankView(container: container)
     }
 }

--- a/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntent.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntent.swift
@@ -1,9 +1,41 @@
-//
-//  StudentRankIntent.swift
-//  StackKnowledge
-//
-//  Created by 정윤서 on 7/16/24.
-//  Copyright © 2024 team.filo. All rights reserved.
-//
-
 import Foundation
+
+import Service
+
+final class StudentRankIntent: StudentRankIntentProtocol {
+    private weak var model: StudentRankModelActionsProtocol?
+    private let fetchMyInfoUseCase: any FetchMyInfoUseCase
+    private let fetchPointRankingListUseCase: any FetchPointRankingListUseCase
+
+    init(
+        model: StudentRankModelActionsProtocol?,
+        fetchMyInfoUseCase: any FetchMyInfoUseCase,
+        fetchPointRankingListUseCase: any FetchPointRankingListUseCase
+    ) {
+        self.model = model
+        self.fetchMyInfoUseCase = fetchMyInfoUseCase
+        self.fetchPointRankingListUseCase = fetchPointRankingListUseCase
+    }
+
+    func onAppear() {
+        Task {
+            do {
+                let info = try await fetchMyInfo()
+                let list = try await fetchRankingList()
+
+                model?.updateMyInfo(info: info)
+                model?.updateRankingList(list: list)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    func fetchMyInfo() async throws -> MyInfoEntity {
+        return try await fetchMyInfoUseCase()
+    }
+
+    func fetchRankingList() async throws -> [PointRankingListEntity] {
+        return try await fetchPointRankingListUseCase()
+    }
+}

--- a/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntent.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntent.swift
@@ -1,0 +1,9 @@
+//
+//  StudentRankIntent.swift
+//  StackKnowledge
+//
+//  Created by 정윤서 on 7/16/24.
+//  Copyright © 2024 team.filo. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntentProtocol.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntentProtocol.swift
@@ -1,9 +1,5 @@
-//
-//  StudentRankIntentProtocol.swift
-//  StackKnowledge
-//
-//  Created by 정윤서 on 7/16/24.
-//  Copyright © 2024 team.filo. All rights reserved.
-//
-
 import Foundation
+
+protocol StudentRankIntentProtocol {
+    func onAppear()
+}

--- a/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntentProtocol.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Intent/StudentRankIntentProtocol.swift
@@ -1,0 +1,9 @@
+//
+//  StudentRankIntentProtocol.swift
+//  StackKnowledge
+//
+//  Created by 정윤서 on 7/16/24.
+//  Copyright © 2024 team.filo. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModel.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModel.swift
@@ -1,9 +1,35 @@
-//
-//  StudentRankModel.swift
-//  StackKnowledge
-//
-//  Created by 정윤서 on 7/16/24.
-//  Copyright © 2024 team.filo. All rights reserved.
-//
-
 import Foundation
+
+import Service
+
+final class StudentRankModel: ObservableObject, StudentRankModelStateProtocol {
+    var myInfo: MyInfoEntity? {
+        get {
+            _myInfo.map {
+                MyInfoEntity(
+                    currentPoint: $0.currentPoint,
+                    cumulatePoint: $0.cumulatePoint,
+                    ranking: $0.ranking,
+                    user: UserInfoEntity(
+                        userId: $0.user.userId,
+                        userName: $0.user.userName,
+                        profileImage: $0.user.profileImage
+                    )
+                )
+            }
+        }
+        set { _myInfo = newValue }
+    }
+    @Published var _myInfo: MyInfoEntity?
+    @Published var rankingList: [PointRankingListEntity] = []
+}
+
+extension StudentRankModel: StudentRankModelActionsProtocol {
+    func updateMyInfo(info: MyInfoEntity) {
+        self.myInfo = info
+    }
+
+    func updateRankingList(list: [PointRankingListEntity]) {
+        self.rankingList = list
+    }
+}

--- a/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModel.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModel.swift
@@ -1,0 +1,9 @@
+//
+//  StudentRankModel.swift
+//  StackKnowledge
+//
+//  Created by 정윤서 on 7/16/24.
+//  Copyright © 2024 team.filo. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModelProtocol.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModelProtocol.swift
@@ -1,9 +1,13 @@
-//
-//  StudentRankModelProtocol.swift
-//  StackKnowledge
-//
-//  Created by 정윤서 on 7/16/24.
-//  Copyright © 2024 team.filo. All rights reserved.
-//
-
 import Foundation
+
+import Service
+
+protocol StudentRankModelStateProtocol {
+    var myInfo: MyInfoEntity? { get }
+    var rankingList: [PointRankingListEntity] { get }
+}
+
+protocol StudentRankModelActionsProtocol: AnyObject {
+    func updateMyInfo(info: MyInfoEntity)
+    func updateRankingList(list: [PointRankingListEntity])
+}

--- a/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModelProtocol.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Model/StudentRankModelProtocol.swift
@@ -1,0 +1,9 @@
+//
+//  StudentRankModelProtocol.swift
+//  StackKnowledge
+//
+//  Created by 정윤서 on 7/16/24.
+//  Copyright © 2024 team.filo. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Presentation/StudentRank/Source/Scene/StudentRankView.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Scene/StudentRankView.swift
@@ -1,9 +1,52 @@
 import SwiftUI
 
+import Service
+
 struct StudentRankView: View {
+    @StateObject var container: MVIContainer<StudentRankIntentProtocol, StudentRankModelStateProtocol>
+    var intent: any StudentRankIntentProtocol { container.intent }
+    var state: any StudentRankModelStateProtocol { container.model }
+    var myInfo: MyInfoEntity? {
+        state.myInfo
+    }
+
     var body: some View {
-        VStack(spacing: 0) {
-            Text("Rank View!!!")
+        VStack(spacing: 60) {
+            MyRankView(
+                profileURL: myInfo?.user.profileImage,
+                ranking: myInfo?.ranking ?? 0,
+                name: myInfo?.user.userName ?? "",
+                point: myInfo?.currentPoint ?? 0
+            )
+            .padding(.top, 60)
+
+            Spacer()
+            
+            VStack(alignment: .leading) {
+                Text("랭킹")
+                    .skFont(.pm20)
+                
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 12) {
+                        ForEach(state.rankingList.indices, id: \.self) { index in
+                            let rank = state.rankingList[index]
+                            
+                            RankingListRow(
+                                ranking: "\(index + 1)",
+                                profileURL: rank.user.profileImage,
+                                name: rank.user.userName,
+                                point: rank.cumulatePoint
+                            )
+
+                            Divider()
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+
+                Spacer()
+            }
         }
+        .padding(.horizontal, 16)
     }
 }

--- a/App/Sources/Presentation/StudentRank/Source/Scene/View/MyRankView.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Scene/View/MyRankView.swift
@@ -1,0 +1,2 @@
+import Foundation
+

--- a/App/Sources/Presentation/StudentRank/Source/Scene/View/MyRankView.swift
+++ b/App/Sources/Presentation/StudentRank/Source/Scene/View/MyRankView.swift
@@ -1,2 +1,42 @@
-import Foundation
+import SwiftUI
 
+struct MyRankView: View {
+    let profileURL: String?
+    let ranking: Int
+    let name: String
+    let point: Int
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let profileURL = profileURL {
+                AsyncImage(url: URL(string: profileURL)) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .scaledToFit()
+                .clipShape(Circle())
+                .frame(width: 110, height: 110)
+            } else {
+                SKBaseProfileImage(.BaseProfileImage)
+                    .scaledToFit()
+                    .clipShape(Circle())
+                    .frame(width: 110, height: 110)
+            }
+
+            HStack(spacing: 6) {
+                Text("\(ranking.description)위")
+
+                Divider()
+
+                Text(name)
+
+                Divider()
+
+                Text("\(point.description)M")
+            }
+            .skFont(.pm14)
+            .frame(height: 17)
+        }
+    }
+}

--- a/App/Sources/Presentation/TeacherRank/Source/DI/TeacherRankComponent.swift
+++ b/App/Sources/Presentation/TeacherRank/Source/DI/TeacherRankComponent.swift
@@ -13,7 +13,7 @@ public final class TeacherRankComponent: Component<TeacherRankDependency>, Teach
         let intent = TeacherRankIntent(model: model, fetchPointRankingListUseCase: dependency.fetchPointRankingListUseCase)
 
         let container = MVIContainer(
-            intent: intent,
+            intent: intent as TeacherRankIntentProtocol,
             model: model as TeacherRankModelStateProtocol,
             modelChangePublisher: model.objectWillChange
         )

--- a/App/Sources/Presentation/TeacherRank/Source/Intent/TeacherRankIntent.swift
+++ b/App/Sources/Presentation/TeacherRank/Source/Intent/TeacherRankIntent.swift
@@ -19,7 +19,7 @@ final class TeacherRankIntent: TeacherRankIntentProtocol {
             do {
                 let rankingList = try await fetchPointRankingListUseCase()
                 
-                model?.updateRankingList(rankingList: rankingList)
+                model?.updateRankingList(list: rankingList)
             } catch {
                 print(error.localizedDescription)
             }

--- a/App/Sources/Presentation/TeacherRank/Source/Model/TeacherRankModel.swift
+++ b/App/Sources/Presentation/TeacherRank/Source/Model/TeacherRankModel.swift
@@ -3,11 +3,11 @@ import Foundation
 import Service
 
 final class TeacherRankModel: ObservableObject, TeacherRankModelStateProtocol {
-    var rankingList: [PointRankingListEntity] = [.init(rankingID: "1", cumulatePoint: 1000, user: .init(userId: "0115", userName: "이주연", profileImage: "https://thumb.pann.com/tc_480/http://fimg5.pann.com/new/download.jsp?FileID=64425399"))]
+    @Published var rankingList: [PointRankingListEntity] = []
 }
 
 extension TeacherRankModel: TeacherRankModelActionsProtocol {
-    func updateRankingList(rankingList: [PointRankingListEntity]) {
-        self.rankingList = rankingList
+    func updateRankingList(list: [PointRankingListEntity]) {
+        self.rankingList = list
     }
 }

--- a/App/Sources/Presentation/TeacherRank/Source/Model/TeacherRankModelProtocol.swift
+++ b/App/Sources/Presentation/TeacherRank/Source/Model/TeacherRankModelProtocol.swift
@@ -7,5 +7,5 @@ protocol TeacherRankModelStateProtocol {
 }
 
 protocol TeacherRankModelActionsProtocol: AnyObject {
-    func updateRankingList(rankingList: [PointRankingListEntity])
+    func updateRankingList(list: [PointRankingListEntity])
 }

--- a/App/Sources/Presentation/TeacherRank/Source/Scene/TeacherRankView.swift
+++ b/App/Sources/Presentation/TeacherRank/Source/Scene/TeacherRankView.swift
@@ -1,27 +1,25 @@
 import SwiftUI
 
 struct TeacherRankView: View {
-    @StateObject var container: MVIContainer<TeacherRankIntent, TeacherRankModelStateProtocol>
+    @StateObject var container: MVIContainer<TeacherRankIntentProtocol, TeacherRankModelStateProtocol>
     var intent: any TeacherRankIntentProtocol { container.intent }
     var state: any TeacherRankModelStateProtocol { container.model }
 
     var body: some View {
         NavigationView {
-            VStack(spacing: 0) {
-                LazyVStack(spacing: 12) {
+            ScrollView {
+                LazyVStack(spacing: 4) {
                     ForEach(state.rankingList.indices, id: \.self) { index in
                         let rankingList = state.rankingList[safe: index]
                         
-                        if let ranking = rankingList {
-                            RankingListRow(
-                                ranking: "\(index + 1)",
-                                profileImage: ranking.user.profileImage,
-                                name: ranking.user.userName,
-                                point: ranking.cumulatePoint
-                            )
-                            .padding(.horizontal, 8)
-                        }
-                        
+                        RankingListRow(
+                            ranking: "\(index + 1)",
+                            profileURL: rankingList?.user.profileImage,
+                            name: rankingList?.user.userName ?? "",
+                            point: rankingList?.cumulatePoint ?? 0
+                        )
+                        .padding(.horizontal, 8)
+
                         Divider()
                     }
                 }

--- a/Service/Sources/Domain/StudentDomain/Interface/Entity/MyInfoEntity.swift
+++ b/Service/Sources/Domain/StudentDomain/Interface/Entity/MyInfoEntity.swift
@@ -3,15 +3,18 @@ import Foundation
 public struct MyInfoEntity: Equatable {
     public let currentPoint: Int
     public let cumulatePoint: Int
+    public let ranking: Int
     public let user: UserInfoEntity
 
     public init(
         currentPoint: Int,
         cumulatePoint: Int,
+        ranking: Int,
         user: UserInfoEntity
     ) {
         self.currentPoint = currentPoint
         self.cumulatePoint = cumulatePoint
+        self.ranking = ranking
         self.user = user
     }
 }

--- a/Service/Sources/Domain/StudentDomain/Sources/DTO/FetchMyInfoResponseDTO.swift
+++ b/Service/Sources/Domain/StudentDomain/Sources/DTO/FetchMyInfoResponseDTO.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct FetchMyInfoResponseDTO: Decodable {
     public let currentPoint: Int
     public let cumulatePoint: Int
+    public let ranking: Int
     public let user: FetchUserInfoResponseDTO
 }
 
@@ -11,6 +12,7 @@ extension FetchMyInfoResponseDTO {
         MyInfoEntity(
             currentPoint: currentPoint,
             cumulatePoint: cumulatePoint,
+            ranking: ranking,
             user: user.toDomain()
         )
     }


### PR DESCRIPTION

https://github.com/user-attachments/assets/ede3db71-ec10-4c51-98ff-da7d4900bda5

- 학생 랭킹 페이지를 제작했어요.
- RankingListRow에 프로필 사진이 옵셔널 처리가 되어있지 않아서 옵셔널로 처리했어요.
- RootView에서 학생페이지로 이동해야하는데 선생님 페이지로 이동해서 수정했어요.
- MyInfoEntity에 ranking을 추가했어요.
- TeacherRank에 파라미터 이름을 수정했어요.
- TeacherRankView에 랭킹 리스트가 ScrollView 처리가 되어있지 않아서 ScrollView로 변경했어요!!